### PR TITLE
feat(storage): align filesystem layout with blob staging architecture

### DIFF
--- a/services/storage/.env
+++ b/services/storage/.env
@@ -4,7 +4,7 @@ GRPC_PORT=50053
 
 # Storage
 DATA_DIR=/data/blobs
-MULTIPART_DIR=/data/multipart
+MULTIPART_DIR=/data/staging
 
 # Logger
 LOGGER_LEVEL=DEBUG

--- a/services/storage/README.md
+++ b/services/storage/README.md
@@ -204,8 +204,8 @@ Gateway                          Storage
 
 | Переменная | По умолчанию | Описание |
 |---|---|---|
-| `DATA_DIR` | `/data/blobs` | Директория для хранения blob-файлов |
-| `MULTIPART_DIR` | `/data/multipart` | Директория для временных частей multipart |
+| `DATA_DIR` | `/data/blobs` | Корневая директория для финальных blob (`<shard>/<blob_id>`) |
+| `MULTIPART_DIR` | `/data/staging` | Корневая директория staging-зоны (`uploads/` + `completed/`) |
 | `RATE_LIMITER_LIMIT` | `100` | Максимум запросов в окно |
 | `RATE_LIMITER_PERIOD` | `1s` | Окно rate limiter |
 
@@ -216,7 +216,7 @@ GRPC_HOST=0.0.0.0
 GRPC_PORT=50053
 
 DATA_DIR=/data/blobs
-MULTIPART_DIR=/data/multipart
+MULTIPART_DIR=/data/staging
 
 LOGGER_LEVEL=DEBUG
 LOGGER_AS_JSON=false
@@ -305,30 +305,33 @@ CLI создаёт multipart session, загружает 2 части неско
 
 ```
 DATA_DIR/                            (по умолчанию /data/blobs)
-├── {blob_id}                        ← финальные объекты (UUID v4)
-├── {blob_id}
+├── ab/
+│   └── abcd1111-2222-3333-4444-555566667777
+├── c4/
+│   └── c4ef1111-2222-3333-4444-555566667777
 └── ...
 
-MULTIPART_DIR/                       (по умолчанию /data/multipart)
+MULTIPART_DIR/                       (по умолчанию /data/staging)
 ├── completed/
-│   ├── {upload_id}.json            ← persisted result completed multipart upload
+│   ├── ab/
+│   │   └── abcd1111-2222-3333-4444-555566667777.json
 │   └── ...
-├── {upload_id}/
-│   ├── meta.json                    ← expected_parts + content_type + blob_id
-│   ├── part_1
-│   ├── part_2
-│   └── ...
-└── {upload_id}/
-    └── ...
+└── uploads/
+    ├── {upload_id}/
+    │   ├── manifest.json            ← expected_parts + content_type + blob_id
+    │   ├── part_00001
+    │   ├── part_00002
+    │   └── ...
+    └── {blob_id}/
+        ├── manifest.json            ← staging single-part upload
+        └── object.bin
 ```
 
-- `blob_id` — UUID v4, генерируется сервисом при `StoreObject`; для multipart фиксируется при `InitiateMultipartUpload` и затем переиспользуется в `CompleteMultipartUpload`
-- `upload_id` — UUID v4, генерируется при `InitiateMultipartUpload`
-- После успешного `CompleteMultipartUpload` session cleanup выполняется best-effort; идемпотентность retry обеспечивается через `completed/{upload_id}.json`
+- `blob_id` — UUID v4, генерируется сервисом при `StoreObject`; финальный файл публикуется как `DATA_DIR/{blob_id[0:2]}/{blob_id}`
+- `upload_id` — UUID v4, генерируется при `InitiateMultipartUpload`; multipart-части складываются в `MULTIPART_DIR/uploads/{upload_id}/`
+- Single-part upload тоже проходит через staging: сначала создаётся `object.bin`, затем файл атомарно публикуется в `blobs/`
+- После успешного `CompleteMultipartUpload` session cleanup выполняется best-effort; идемпотентность retry обеспечивается через `completed/{upload_id[0:2]}/{upload_id}.json`
 - Для атомарной записи используются уникальные temp-файлы с последующим `os.Rename`, поэтому stale `*.tmp` после crash не должны ломать retry
-
-> **Рекомендация:** для production с большим количеством файлов стоит использовать
-> вложенность `DATA_DIR/{blob_id[0:2]}/{blob_id}` (шардирование по первым 2 символам UUID).
 
 ---
 

--- a/services/storage/internal/config/env/storage.go
+++ b/services/storage/internal/config/env/storage.go
@@ -6,7 +6,7 @@ import (
 
 type storageEnvConfig struct {
 	DataDir      string `env:"DATA_DIR" envDefault:"/data/blobs"`
-	MultipartDir string `env:"MULTIPART_DIR" envDefault:"/data/multipart"`
+	MultipartDir string `env:"MULTIPART_DIR" envDefault:"/data/staging"`
 }
 
 type storageConfig struct {

--- a/services/storage/internal/repository/storage/multipart.go
+++ b/services/storage/internal/repository/storage/multipart.go
@@ -17,7 +17,7 @@ import (
 	"go.uber.org/zap"
 )
 
-const multipartMetaFilename = "meta.json"
+const multipartMetaFilename = stagingManifestFilename
 const multipartCompletionDirname = "completed"
 
 var afterAssemblePartsCommitHook = func(context.Context) {}
@@ -124,7 +124,7 @@ func (r *repo) AssembleParts(ctx context.Context, uploadID string, parts []model
 		destBlobID = sessionMeta.BlobID
 	}
 
-	if err := ensureDirReady(r.dataDir); err != nil {
+	if err := ensureDirReady(r.blobsRootPath()); err != nil {
 		return nil, err
 	}
 
@@ -269,15 +269,15 @@ func (r *repo) writeCompletedMultipartMeta(uploadID string, meta *model.BlobMeta
 }
 
 func (r *repo) multipartSessionPath(uploadID string) string {
-	return filepath.Join(r.multipartDir, uploadID)
+	return filepath.Join(r.stagingUploadsPath(), uploadID)
 }
 
 func (r *repo) multipartCompletedDir() string {
-	return filepath.Join(r.multipartDir, multipartCompletionDirname)
+	return filepath.Join(r.stagingRootPath(), multipartCompletionDirname)
 }
 
 func (r *repo) completedMultipartMetaPath(uploadID string) string {
-	return filepath.Join(r.multipartCompletedDir(), uploadID+".json")
+	return filepath.Join(r.multipartCompletedDir(), completedMetaShard(uploadID), uploadID+".json")
 }
 
 func (r *repo) multipartMetaPath(uploadID string) string {
@@ -285,7 +285,7 @@ func (r *repo) multipartMetaPath(uploadID string) string {
 }
 
 func (r *repo) multipartPartPath(uploadID string, partNumber int32) string {
-	return filepath.Join(r.multipartSessionPath(uploadID), fmt.Sprintf("part_%d", partNumber))
+	return filepath.Join(r.multipartSessionPath(uploadID), fmt.Sprintf("part_%05d", partNumber))
 }
 
 func (r *repo) multipartSessionExists(uploadID string) bool {
@@ -355,4 +355,8 @@ func (r *repo) blobExists(blobID string) (bool, error) {
 
 func blobIDForUpload(uploadID string) string {
 	return uploadID
+}
+
+func completedMetaShard(uploadID string) string {
+	return blobShard(uploadID)
 }

--- a/services/storage/internal/repository/storage/multipart_internal_test.go
+++ b/services/storage/internal/repository/storage/multipart_internal_test.go
@@ -44,7 +44,7 @@ func TestAssembleParts_CleanupUsesDetachedContext(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, meta)
 
-	_, statErr := os.Stat(filepath.Join(multipartDir, "upload-1"))
+	_, statErr := os.Stat(filepath.Join(multipartDir, stagingUploadsDirname, "upload-1"))
 	require.ErrorIs(t, statErr, os.ErrNotExist)
 }
 
@@ -85,6 +85,6 @@ func TestAssembleParts_CanceledBeforeNextPartCopyLeavesNoBlob(t *testing.T) {
 	require.ErrorIs(t, err, context.Canceled)
 	require.Nil(t, meta)
 
-	_, statErr := os.Stat(filepath.Join(dataDir, "upload-1"))
+	_, statErr := os.Stat(filepath.Join(dataDir, "up", "upload-1"))
 	require.ErrorIs(t, statErr, os.ErrNotExist)
 }

--- a/services/storage/internal/repository/storage/repository.go
+++ b/services/storage/internal/repository/storage/repository.go
@@ -16,3 +16,10 @@ func NewRepository(cfg config.StorageConfig) repository.StorageRepository {
 		multipartDir: cfg.MultipartDir(),
 	}
 }
+
+const (
+	blobsShardLength        = 2
+	stagingUploadsDirname   = "uploads"
+	stagingObjectFilename   = "object.bin"
+	stagingManifestFilename = "manifest.json"
+)

--- a/services/storage/internal/repository/storage/store_blob.go
+++ b/services/storage/internal/repository/storage/store_blob.go
@@ -1,10 +1,13 @@
 package storage
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"path/filepath"
 	"syscall"
 
@@ -17,14 +20,33 @@ func (r *repo) StoreBlob(ctx context.Context, blobID string, reader io.Reader) (
 		return nil, err
 	}
 
-	if err := ensureDirReady(r.dataDir); err != nil {
+	if err := ensureDirReady(r.blobsRootPath()); err != nil {
 		return nil, err
 	}
 
-	result, err := writeAtomically(ctx, r.blobPath(blobID), reader, "blob")
+	stagingDir := r.singlePartUploadPath(blobID)
+	if err := ensureDirReady(stagingDir); err != nil {
+		return nil, err
+	}
+
+	if err := r.writeSinglePartManifest(blobID); err != nil {
+		return nil, err
+	}
+
+	result, err := writeAtomically(ctx, r.singlePartObjectPath(blobID), reader, "staged blob")
 	if err != nil {
 		return nil, err
 	}
+
+	if err := ensureDirReady(filepath.Dir(r.blobPath(blobID))); err != nil {
+		return nil, err
+	}
+
+	if err := os.Rename(r.singlePartObjectPath(blobID), r.blobPath(blobID)); err != nil {
+		return nil, fmt.Errorf("publish staged blob file: %w", err)
+	}
+
+	r.cleanupSinglePartStagingBestEffort(blobID)
 
 	return &model.BlobMeta{
 		BlobID:      blobID,
@@ -34,7 +56,65 @@ func (r *repo) StoreBlob(ctx context.Context, blobID string, reader io.Reader) (
 }
 
 func (r *repo) blobPath(blobID string) string {
-	return filepath.Join(r.dataDir, blobID)
+	return filepath.Join(r.blobsRootPath(), blobShard(blobID), blobID)
+}
+
+func (r *repo) blobsRootPath() string {
+	return r.dataDir
+}
+
+func blobShard(blobID string) string {
+	if len(blobID) < blobsShardLength {
+		return blobID
+	}
+
+	return blobID[:blobsShardLength]
+}
+
+func (r *repo) stagingRootPath() string {
+	return r.multipartDir
+}
+
+func (r *repo) stagingUploadsPath() string {
+	return filepath.Join(r.stagingRootPath(), stagingUploadsDirname)
+}
+
+func (r *repo) singlePartUploadPath(blobID string) string {
+	return filepath.Join(r.stagingUploadsPath(), blobID)
+}
+
+func (r *repo) singlePartObjectPath(blobID string) string {
+	return filepath.Join(r.singlePartUploadPath(blobID), stagingObjectFilename)
+}
+
+func (r *repo) writeSinglePartManifest(blobID string) error {
+	manifestBytes, err := json.Marshal(struct {
+		BlobID string `json:"blob_id"`
+		State  string `json:"state"`
+	}{
+		BlobID: blobID,
+		State:  "staged",
+	})
+	if err != nil {
+		return fmt.Errorf("marshal staged blob manifest: %w", err)
+	}
+
+	if _, err := writeAtomically(
+		context.Background(),
+		filepath.Join(r.singlePartUploadPath(blobID), stagingManifestFilename),
+		bytes.NewReader(manifestBytes),
+		"staged blob manifest",
+	); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (r *repo) cleanupSinglePartStagingBestEffort(blobID string) {
+	// Single-part uploads are already externally visible once the staged file
+	// is renamed into blobs/, so stale staging is only a cleanup concern.
+	_ = os.RemoveAll(r.singlePartUploadPath(blobID))
 }
 
 func ensureWritableDiskSpace(dir string) error {

--- a/services/storage/internal/repository/storage/tests/assemble_parts_test.go
+++ b/services/storage/internal/repository/storage/tests/assemble_parts_test.go
@@ -70,7 +70,7 @@ func TestAssembleParts_Success(t *testing.T) {
 	require.Equal(t, append(partOne, partTwo...), body)
 	require.Equal(t, fmt.Sprintf("%x", md5.Sum(body)), meta.ChecksumMD5)
 
-	_, err = os.Stat(filepath.Join(multipartDir, "upload-1"))
+	_, err = os.Stat(multipartSessionPath(multipartDir, "upload-1"))
 	require.ErrorIs(t, err, os.ErrNotExist)
 
 	retryMeta, err := repository.AssembleParts(context.Background(), "upload-1", parts, "blob-retry")
@@ -100,7 +100,7 @@ func TestAssembleParts_ChecksumMismatch(t *testing.T) {
 	require.ErrorIs(t, err, domainerrors.ErrChecksumMismatch)
 	require.Nil(t, meta)
 
-	_, err = os.Stat(filepath.Join(dataDir, "upload-1"))
+	_, err = os.Stat(blobFilePath(dataDir, "upload-1"))
 	require.ErrorIs(t, err, os.ErrNotExist)
 }
 
@@ -138,10 +138,10 @@ func TestAssembleParts_SucceedsWhenCleanupFails(t *testing.T) {
 	part := []byte("hello world")
 	checksum := setupMultipartSinglePart(t, repository, "upload-1", part)
 
-	require.NoError(t, os.Mkdir(filepath.Join(multipartDir, "completed"), 0o755))
-	require.NoError(t, os.Chmod(multipartDir, 0o555))
+	require.NoError(t, os.MkdirAll(filepath.Dir(completedMetaPath(multipartDir, "upload-1")), 0o755))
+	require.NoError(t, os.Chmod(stagingUploadsPath(multipartDir), 0o555))
 	t.Cleanup(func() {
-		_ = os.Chmod(multipartDir, 0o755)
+		_ = os.Chmod(stagingUploadsPath(multipartDir), 0o755)
 	})
 
 	meta, err := repository.AssembleParts(context.Background(), "upload-1", []model.PartInfo{
@@ -151,11 +151,11 @@ func TestAssembleParts_SucceedsWhenCleanupFails(t *testing.T) {
 	require.NotNil(t, meta)
 	require.Equal(t, "upload-1", meta.BlobID)
 
-	body, readErr := os.ReadFile(filepath.Join(dataDir, "upload-1"))
+	body, readErr := os.ReadFile(blobFilePath(dataDir, "upload-1"))
 	require.NoError(t, readErr)
 	require.Equal(t, part, body)
 
-	_, statErr := os.Stat(filepath.Join(multipartDir, "upload-1"))
+	_, statErr := os.Stat(multipartSessionPath(multipartDir, "upload-1"))
 	require.NoError(t, statErr)
 }
 
@@ -172,10 +172,10 @@ func TestAssembleParts_IdempotentRetryAfterCleanupFailure(t *testing.T) {
 	part := []byte("hello world")
 	checksum := setupMultipartSinglePart(t, repository, "upload-1", part)
 
-	require.NoError(t, os.Mkdir(filepath.Join(multipartDir, "completed"), 0o755))
-	require.NoError(t, os.Chmod(multipartDir, 0o555))
+	require.NoError(t, os.MkdirAll(filepath.Dir(completedMetaPath(multipartDir, "upload-1")), 0o755))
+	require.NoError(t, os.Chmod(stagingUploadsPath(multipartDir), 0o555))
 	t.Cleanup(func() {
-		_ = os.Chmod(multipartDir, 0o755)
+		_ = os.Chmod(stagingUploadsPath(multipartDir), 0o755)
 	})
 
 	firstMeta, err := repository.AssembleParts(context.Background(), "upload-1", []model.PartInfo{
@@ -194,7 +194,7 @@ func TestAssembleParts_IdempotentRetryAfterCleanupFailure(t *testing.T) {
 	entries, readErr := os.ReadDir(dataDir)
 	require.NoError(t, readErr)
 	require.Len(t, entries, 1)
-	require.Equal(t, "upload-1", entries[0].Name())
+	require.Equal(t, blobShardDirName("upload-1"), entries[0].Name())
 }
 
 func TestAssembleParts_FallsBackWhenCompletedMetaIsCorrupted(t *testing.T) {
@@ -210,9 +210,8 @@ func TestAssembleParts_FallsBackWhenCompletedMetaIsCorrupted(t *testing.T) {
 	part := []byte("hello world")
 	checksum := setupMultipartSinglePart(t, repository, "upload-1", part)
 
-	completedDir := filepath.Join(multipartDir, "completed")
-	require.NoError(t, os.MkdirAll(completedDir, 0o755))
-	require.NoError(t, os.WriteFile(filepath.Join(completedDir, "upload-1.json"), []byte("{"), 0o644))
+	require.NoError(t, os.MkdirAll(filepath.Dir(completedMetaPath(multipartDir, "upload-1")), 0o755))
+	require.NoError(t, os.WriteFile(completedMetaPath(multipartDir, "upload-1"), []byte("{"), 0o644))
 
 	meta, err := repository.AssembleParts(context.Background(), "upload-1", []model.PartInfo{
 		{PartNumber: 1, ChecksumMD5: checksum},
@@ -221,11 +220,11 @@ func TestAssembleParts_FallsBackWhenCompletedMetaIsCorrupted(t *testing.T) {
 	require.NotNil(t, meta)
 	require.Equal(t, "upload-1", meta.BlobID)
 
-	body, readErr := os.ReadFile(filepath.Join(dataDir, "upload-1"))
+	body, readErr := os.ReadFile(blobFilePath(dataDir, "upload-1"))
 	require.NoError(t, readErr)
 	require.Equal(t, part, body)
 
-	completedMetaBytes, readMetaErr := os.ReadFile(filepath.Join(completedDir, "upload-1.json"))
+	completedMetaBytes, readMetaErr := os.ReadFile(completedMetaPath(multipartDir, "upload-1"))
 	require.NoError(t, readMetaErr)
 
 	var completedMeta model.BlobMeta
@@ -246,8 +245,7 @@ func TestAssembleParts_RebuildsWhenCompletedMetaExistsButBlobIsMissing(t *testin
 	part := []byte("hello world")
 	checksum := setupMultipartSinglePart(t, repository, "upload-1", part)
 
-	completedDir := filepath.Join(multipartDir, "completed")
-	require.NoError(t, os.MkdirAll(completedDir, 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Dir(completedMetaPath(multipartDir, "upload-1")), 0o755))
 
 	completedMetaBytes, err := json.Marshal(model.BlobMeta{
 		BlobID:      "upload-1",
@@ -256,7 +254,7 @@ func TestAssembleParts_RebuildsWhenCompletedMetaExistsButBlobIsMissing(t *testin
 		ContentType: "video/mp4",
 	})
 	require.NoError(t, err)
-	require.NoError(t, os.WriteFile(filepath.Join(completedDir, "upload-1.json"), completedMetaBytes, 0o644))
+	require.NoError(t, os.WriteFile(completedMetaPath(multipartDir, "upload-1"), completedMetaBytes, 0o644))
 
 	meta, err := repository.AssembleParts(context.Background(), "upload-1", []model.PartInfo{
 		{PartNumber: 1, ChecksumMD5: checksum},
@@ -266,7 +264,7 @@ func TestAssembleParts_RebuildsWhenCompletedMetaExistsButBlobIsMissing(t *testin
 	require.Equal(t, "upload-1", meta.BlobID)
 	require.Equal(t, int64(len(part)), meta.SizeBytes)
 
-	body, readErr := os.ReadFile(filepath.Join(dataDir, "upload-1"))
+	body, readErr := os.ReadFile(blobFilePath(dataDir, "upload-1"))
 	require.NoError(t, readErr)
 	require.Equal(t, part, body)
 
@@ -287,9 +285,8 @@ func TestAssembleParts_CorruptedCompletedMetaWithoutSessionReturnsUploadNotFound
 		multipartDir: multipartDir,
 	})
 
-	completedDir := filepath.Join(multipartDir, "completed")
-	require.NoError(t, os.MkdirAll(completedDir, 0o755))
-	require.NoError(t, os.WriteFile(filepath.Join(completedDir, "upload-1.json"), []byte("{"), 0o644))
+	require.NoError(t, os.MkdirAll(filepath.Dir(completedMetaPath(multipartDir, "upload-1")), 0o755))
+	require.NoError(t, os.WriteFile(completedMetaPath(multipartDir, "upload-1"), []byte("{"), 0o644))
 
 	meta, err := repository.AssembleParts(context.Background(), "upload-1", []model.PartInfo{
 		{PartNumber: 1, ChecksumMD5: "unused"},
@@ -311,7 +308,8 @@ func TestAssembleParts_IgnoresStaleTempFileOnRetry(t *testing.T) {
 	part := []byte("hello world")
 	checksum := setupMultipartSinglePart(t, repository, "upload-1", part)
 
-	require.NoError(t, os.WriteFile(filepath.Join(dataDir, "upload-1.tmp"), []byte("stale temp"), 0o644))
+	require.NoError(t, os.MkdirAll(filepath.Dir(blobFilePath(dataDir, "upload-1")), 0o755))
+	require.NoError(t, os.WriteFile(blobFilePath(dataDir, "upload-1")+".tmp", []byte("stale temp"), 0o644))
 
 	meta, err := repository.AssembleParts(context.Background(), "upload-1", []model.PartInfo{
 		{PartNumber: 1, ChecksumMD5: checksum},
@@ -320,7 +318,7 @@ func TestAssembleParts_IgnoresStaleTempFileOnRetry(t *testing.T) {
 	require.NotNil(t, meta)
 	require.Equal(t, "upload-1", meta.BlobID)
 
-	body, readErr := os.ReadFile(filepath.Join(dataDir, "upload-1"))
+	body, readErr := os.ReadFile(blobFilePath(dataDir, "upload-1"))
 	require.NoError(t, readErr)
 	require.Equal(t, part, body)
 }

--- a/services/storage/internal/repository/storage/tests/cleanup_multipart_test.go
+++ b/services/storage/internal/repository/storage/tests/cleanup_multipart_test.go
@@ -3,7 +3,6 @@ package tests
 import (
 	"context"
 	"os"
-	"path/filepath"
 	"testing"
 
 	storageRepo "github.com/alesplll/opens3-rebac/services/storage/internal/repository/storage"
@@ -24,7 +23,7 @@ func TestCleanupMultipart_Success(t *testing.T) {
 	err = repository.CleanupMultipart(context.Background(), "upload-1")
 	require.NoError(t, err)
 
-	_, err = os.Stat(filepath.Join(multipartDir, "upload-1"))
+	_, err = os.Stat(multipartSessionPath(multipartDir, "upload-1"))
 	require.ErrorIs(t, err, os.ErrNotExist)
 }
 

--- a/services/storage/internal/repository/storage/tests/create_multipart_session_test.go
+++ b/services/storage/internal/repository/storage/tests/create_multipart_session_test.go
@@ -23,7 +23,7 @@ func TestCreateMultipartSession_Success(t *testing.T) {
 	err := repository.CreateMultipartSession(context.Background(), "upload-1", 3, "video/mp4")
 	require.NoError(t, err)
 
-	metaPath := filepath.Join(multipartDir, "upload-1", "meta.json")
+	metaPath := filepath.Join(multipartSessionPath(multipartDir, "upload-1"), "manifest.json")
 	metaRaw, err := os.ReadFile(metaPath)
 	require.NoError(t, err)
 

--- a/services/storage/internal/repository/storage/tests/delete_blob_test.go
+++ b/services/storage/internal/repository/storage/tests/delete_blob_test.go
@@ -19,7 +19,8 @@ func TestDeleteBlob_Success(t *testing.T) {
 		multipartDir: t.TempDir(),
 	})
 
-	blobPath := filepath.Join(dataDir, "blob-1")
+	blobPath := blobFilePath(dataDir, "blob-1")
+	require.NoError(t, os.MkdirAll(filepath.Dir(blobPath), 0o755))
 	err := os.WriteFile(blobPath, []byte("content"), 0o644)
 	require.NoError(t, err)
 
@@ -52,13 +53,13 @@ func TestDeleteBlob_RemovesCompletedMultipartMeta(t *testing.T) {
 		multipartDir: multipartDir,
 	})
 
-	blobPath := filepath.Join(dataDir, "upload-1")
+	blobPath := blobFilePath(dataDir, "upload-1")
+	require.NoError(t, os.MkdirAll(filepath.Dir(blobPath), 0o755))
 	require.NoError(t, os.WriteFile(blobPath, []byte("content"), 0o644))
 
-	completedDir := filepath.Join(multipartDir, "completed")
-	require.NoError(t, os.MkdirAll(completedDir, 0o755))
-	completedMetaPath := filepath.Join(completedDir, "upload-1.json")
-	require.NoError(t, os.WriteFile(completedMetaPath, []byte(`{"blob_id":"upload-1"}`), 0o644))
+	metaPath := completedMetaPath(multipartDir, "upload-1")
+	require.NoError(t, os.MkdirAll(filepath.Dir(metaPath), 0o755))
+	require.NoError(t, os.WriteFile(metaPath, []byte(`{"blob_id":"upload-1"}`), 0o644))
 
 	err := repository.DeleteBlob(context.Background(), "upload-1")
 	require.NoError(t, err)
@@ -66,6 +67,6 @@ func TestDeleteBlob_RemovesCompletedMultipartMeta(t *testing.T) {
 	_, err = os.Stat(blobPath)
 	require.ErrorIs(t, err, os.ErrNotExist)
 
-	_, err = os.Stat(completedMetaPath)
+	_, err = os.Stat(metaPath)
 	require.ErrorIs(t, err, os.ErrNotExist)
 }

--- a/services/storage/internal/repository/storage/tests/store_blob_test.go
+++ b/services/storage/internal/repository/storage/tests/store_blob_test.go
@@ -18,9 +18,10 @@ func TestStoreBlob_Success(t *testing.T) {
 	t.Parallel()
 
 	dataDir := t.TempDir()
+	multipartDir := t.TempDir()
 	repository := storageRepo.NewRepository(testStorageConfig{
 		dataDir:      dataDir,
-		multipartDir: t.TempDir(),
+		multipartDir: multipartDir,
 	})
 	content := []byte("storage blob content")
 	blobID := "blob-1"
@@ -31,9 +32,12 @@ func TestStoreBlob_Success(t *testing.T) {
 	require.Equal(t, int64(len(content)), meta.SizeBytes)
 	require.Equal(t, fmt.Sprintf("%x", md5.Sum(content)), meta.ChecksumMD5)
 
-	storedContent, err := os.ReadFile(filepath.Join(dataDir, blobID))
+	storedContent, err := os.ReadFile(blobFilePath(dataDir, blobID))
 	require.NoError(t, err)
 	require.Equal(t, content, storedContent)
+
+	_, err = os.Stat(singlePartUploadPath(multipartDir, blobID))
+	require.ErrorIs(t, err, os.ErrNotExist)
 }
 
 func TestStoreBlob_CleanupTempFileOnReadError(t *testing.T) {
@@ -77,7 +81,7 @@ func TestStoreBlob_LargeFile(t *testing.T) {
 	require.Equal(t, int64(len(content)), meta.SizeBytes)
 	require.Equal(t, fmt.Sprintf("%x", md5.Sum(content)), meta.ChecksumMD5)
 
-	storedContent, err := os.ReadFile(filepath.Join(dataDir, blobID))
+	storedContent, err := os.ReadFile(blobFilePath(dataDir, blobID))
 	require.NoError(t, err)
 	require.Equal(t, content, storedContent)
 }
@@ -98,7 +102,7 @@ func TestStoreBlob_EmptyBlob(t *testing.T) {
 	require.Equal(t, int64(0), meta.SizeBytes)
 	require.Equal(t, "d41d8cd98f00b204e9800998ecf8427e", meta.ChecksumMD5)
 
-	storedContent, err := os.ReadFile(filepath.Join(dataDir, blobID))
+	storedContent, err := os.ReadFile(blobFilePath(dataDir, blobID))
 	require.NoError(t, err)
 	require.Empty(t, storedContent)
 }
@@ -133,14 +137,15 @@ func TestStoreBlob_IgnoresStaleTempFileOnRetry(t *testing.T) {
 	})
 
 	blobID := "blob-1"
-	require.NoError(t, os.WriteFile(filepath.Join(dataDir, blobID)+".tmp", []byte("stale temp"), 0o644))
+	require.NoError(t, os.MkdirAll(filepath.Dir(blobFilePath(dataDir, blobID)), 0o755))
+	require.NoError(t, os.WriteFile(blobFilePath(dataDir, blobID)+".tmp", []byte("stale temp"), 0o644))
 
 	content := []byte("storage blob content")
 	meta, err := repository.StoreBlob(context.Background(), blobID, bytes.NewReader(content))
 	require.NoError(t, err)
 	require.Equal(t, blobID, meta.BlobID)
 
-	storedContent, err := os.ReadFile(filepath.Join(dataDir, blobID))
+	storedContent, err := os.ReadFile(blobFilePath(dataDir, blobID))
 	require.NoError(t, err)
 	require.Equal(t, content, storedContent)
 }
@@ -156,6 +161,43 @@ func (c testStorageConfig) DataDir() string {
 
 func (c testStorageConfig) MultipartDir() string {
 	return c.multipartDir
+}
+
+func blobFilePath(dataDir, blobID string) string {
+	return filepath.Join(dataDir, blobShardDirName(blobID), blobID)
+}
+
+func blobShardDirName(blobID string) string {
+	shard := blobID
+	if len(blobID) >= 2 {
+		shard = blobID[:2]
+	}
+
+	return shard
+}
+
+func stagingUploadsPath(multipartDir string) string {
+	return filepath.Join(multipartDir, "uploads")
+}
+
+func singlePartUploadPath(multipartDir, blobID string) string {
+	return filepath.Join(stagingUploadsPath(multipartDir), blobID)
+}
+
+func multipartSessionPath(multipartDir, uploadID string) string {
+	return filepath.Join(stagingUploadsPath(multipartDir), uploadID)
+}
+
+func multipartPartPath(multipartDir, uploadID string, partNumber int32) string {
+	return filepath.Join(multipartSessionPath(multipartDir, uploadID), fmt.Sprintf("part_%05d", partNumber))
+}
+
+func completedMetaPath(multipartDir, uploadID string) string {
+	return filepath.Join(multipartDir, "completed", completedMetaShardDirName(uploadID), uploadID+".json")
+}
+
+func completedMetaShardDirName(uploadID string) string {
+	return blobShardDirName(uploadID)
 }
 
 type failingReader struct {

--- a/services/storage/internal/repository/storage/tests/store_part_test.go
+++ b/services/storage/internal/repository/storage/tests/store_part_test.go
@@ -31,7 +31,7 @@ func TestStorePart_Success(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, fmt.Sprintf("%x", md5.Sum(content)), checksum)
 
-	partPath := filepath.Join(multipartDir, "upload-1", "part_2")
+	partPath := multipartPartPath(multipartDir, "upload-1", 2)
 	stored, err := os.ReadFile(partPath)
 	require.NoError(t, err)
 	require.Equal(t, content, stored)
@@ -61,7 +61,7 @@ func TestStorePart_IgnoresStaleTempFileOnRetry(t *testing.T) {
 	err := repository.CreateMultipartSession(context.Background(), "upload-1", 2, "video/mp4")
 	require.NoError(t, err)
 
-	partPath := filepath.Join(multipartDir, "upload-1", "part_2")
+	partPath := multipartPartPath(multipartDir, "upload-1", 2)
 	require.NoError(t, os.WriteFile(partPath+".tmp", []byte("stale temp"), 0o644))
 
 	content := []byte("part content")
@@ -94,7 +94,7 @@ func TestStorePart_RetryOverwritesExistingPart(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, fmt.Sprintf("%x", md5.Sum(secondContent)), checksum)
 
-	partPath := filepath.Join(multipartDir, "upload-1", "part_2")
+	partPath := multipartPartPath(multipartDir, "upload-1", 2)
 	stored, err := os.ReadFile(partPath)
 	require.NoError(t, err)
 	require.Equal(t, secondContent, stored)
@@ -131,7 +131,7 @@ func TestStorePart_CanceledDuringWriteCleansUpTempFile(t *testing.T) {
 	err = <-done
 	require.ErrorIs(t, err, context.Canceled)
 
-	partPath := filepath.Join(multipartDir, "upload-1", "part_2")
+	partPath := multipartPartPath(multipartDir, "upload-1", 2)
 	_, statErr := os.Stat(partPath)
 	require.ErrorIs(t, statErr, os.ErrNotExist)
 

--- a/services/storage/internal/repository/storage/write_helpers.go
+++ b/services/storage/internal/repository/storage/write_helpers.go
@@ -72,6 +72,10 @@ func createAtomicTempFile(finalPath string, entity string) (*os.File, string, er
 	dir := filepath.Dir(finalPath)
 	base := filepath.Base(finalPath)
 
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return nil, "", fmt.Errorf("create dir for %s file: %w", entity, err)
+	}
+
 	file, err := os.CreateTemp(dir, base+".*.tmp")
 	if err != nil {
 		return nil, "", fmt.Errorf("create temp %s file: %w", entity, err)

--- a/services/storage/tests.md
+++ b/services/storage/tests.md
@@ -75,7 +75,7 @@
 
 ### `internal/repository/storage/tests/create_multipart_session_test.go`
 
-- `TestCreateMultipartSession_Success` — проверяет создание multipart session directory и `meta.json`.
+- `TestCreateMultipartSession_Success` — проверяет создание multipart session directory в `uploads/` и `manifest.json`.
 
 ### `internal/repository/storage/tests/cleanup_multipart_test.go`
 


### PR DESCRIPTION
  This PR updates the storage service filesystem layout to match the staged blob architecture described in docs/storage-fs-architecture.md. Final blobs are now stored in a sharded layout under DATA_DIR/{blob_id[:2]}/{blob_id}, while staging data is separated into MULTIPART_DIR/uploads/... for both multipart and single-part uploads.

  It also shards multipart completion markers under completed/{upload_id[:2]}/{upload_id}.json, updates storage defaults and local .env, and refreshes repository/component tests plus storage documentation to reflect the new layout.
