### PR TITLE
docs(claude): add working guidelines and per-service CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,6 +153,12 @@ Before implementing anything foundational (handler, service, repository, config,
 
 The canonical reference is **`services/users/`** — it covers handler structure, service layer with interface + mock, PostgreSQL repository, domain models, env config, table-driven tests, and SQL migration layout.
 
+### GitHub (gh CLI)
+- Before any write action (review, comment, close, merge) — show draft and wait for confirmation.
+- Before reviewing a PR — always run `gh pr diff` + `gh pr view` to understand context.
+- Don't guess the intent of changes — ask if unclear.
+- Issue and PR descriptions: concise, no filler.
+
 ### Code style
 - No comments explaining WHAT — only WHY when non-obvious.
 - No speculative abstractions. Implement only what the task requires.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,6 +71,20 @@ Quota :50055 ── Redis ── Kafka
 
 ---
 
+## Service boundaries
+
+| Service | Does NOT |
+|---|---|
+| **AuthZ** | authenticate users, store metadata, handle bytes, know about HTTP |
+| **Metadata** | store bytes, check permissions, know about S3 API |
+| **Storage** | check permissions, store metadata, know about object keys |
+| **Quota** | enforce auth, store metadata, know about blobs |
+| **Auth** | authorize (that's AuthZ), manage user profiles |
+| **Users** | issue tokens, know about S3, check permissions |
+| **Gateway** | store data, make authorization decisions, know about graph structure |
+
+---
+
 ## Roadmap
 
 | Phase | Status | What |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,32 +48,6 @@ Quota :50055 ── Redis ── Kafka
 
 ## Key domain concepts
 
-### AuthZ: entity ID format
-
-All IDs in the AuthZ graph: `prefix:name` — e.g. `user:alice`, `bucket:photos`, `object:photos/cat.jpg`.
-
-### AuthZ: permission hierarchy
-
-```
-read < write < create < delete < admin
-```
-
-A `HAS_PERMISSION` edge with `level: write` also grants `create`, `delete`, `admin`.
-
-### AuthZ: Neo4j edge types
-
-| Edge | Meaning |
-|---|---|
-| `MEMBER_OF` | Group membership (transitive) |
-| `HAS_PERMISSION` | Permission with level |
-| `PARENT_OF` | Resource hierarchy (bucket → object) |
-| `OWNER_OF` | Full access (legacy = admin) |
-
-### AuthZ: Redis cache
-
-Key: `auth_decision:{subject}:{action}:{object}`, TTL 30s.  
-Invalidation: AuthZ publishes to `auth-changes`; `cache_invalidator` process consumes it.
-
 ### S3 → ReBAC mapping
 
 | S3 operation | action | resource |
@@ -85,11 +59,6 @@ Invalidation: AuthZ publishes to `auth-changes`; `cache_invalidator` process con
 | `CreateBucket` | — | no check — any user can create |
 | `DeleteBucket` | `delete` | `bucket:{bucket}` |
 
-### Quota: hot-path architecture
-
-In-memory DashMap (~100ns) → Redis persistence (flush every 1s).  
-Reserve-and-rollback: check user limit → check bucket limit → commit.
-
 ### Kafka topics
 
 | Topic | Producer | Consumer |
@@ -99,20 +68,6 @@ Reserve-and-rollback: check user limit → check bucket limit → commit.
 | `bucket-deleted` | Metadata | AuthZ |
 | `auth-changes` | AuthZ | AuthZ cache_invalidator |
 | `auth-audit` | AuthZ | — (log sink) |
-
----
-
-## Service boundaries
-
-| Service | Does NOT |
-|---|---|
-| **AuthZ** | authenticate users, store metadata, handle bytes, know about HTTP |
-| **Metadata** | store bytes, check permissions, know about S3 API |
-| **Storage** | check permissions, store metadata, know about object keys |
-| **Quota** | enforce auth, store metadata, know about blobs |
-| **Auth** | authorize (that's AuthZ), manage user profiles |
-| **Users** | issue tokens, know about S3, check permissions |
-| **Gateway** | store data, make authorization decisions, know about graph structure |
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,11 +153,23 @@ Before implementing anything foundational (handler, service, repository, config,
 
 The canonical reference is **`services/users/`** — it covers handler structure, service layer with interface + mock, PostgreSQL repository, domain models, env config, table-driven tests, and SQL migration layout.
 
+### Branches
+- Format: `type/scope-description` — e.g. `feat/authz-cache-invalidation`, `fix/users-uuid-parsing`.
+
+### Issues
+- Title: specific and actionable — what's broken or what needs to be done.
+- Body: `## What` (2-3 sentences) + `## Acceptance criteria` (checklist).
+- For bugs: include reproduction steps in the What section.
+
+### Pull requests
+- Title format matches commits: `type(scope): short description`.
+- Link to issue via `closes #N` in PR body when applicable.
+- Descriptions: concise, no filler.
+
 ### GitHub (gh CLI)
 - Before any write action (review, comment, close, merge) — show draft and wait for confirmation.
 - Before reviewing a PR — always run `gh pr diff` + `gh pr view` to understand context.
 - Don't guess the intent of changes — ask if unclear.
-- Issue and PR descriptions: concise, no filler.
 
 ### Code style
 - No comments explaining WHAT — only WHY when non-obvious.

--- a/services/auth/CLAUDE.md
+++ b/services/auth/CLAUDE.md
@@ -9,23 +9,28 @@ Port: `:50050`
 ## Architecture
 
 ```
-cmd/main.go → app/app.go → service_provider.go (DI)
+cmd/server/main.go → internal/app/app.go → internal/app/service_provider.go (DI)
 
-handler/auth/
+internal/handler/auth/
+  handler.go           — implements AuthServiceServer
   login.go             — Login RPC: validate credentials via Users client → issue tokens
   get_access_token.go  — reissue access token from refresh token
   get_refresh_token.go — reissue refresh token
   validate_token.go    — ValidateToken RPC: verify JWT, return claims
 
-service/auth/
-  service.go           — orchestrates UserClient + TokenService + Repository
-  verify_token.go
-  get_access_token.go
-  get_refresh_token.go
+internal/service/
+  service.go           — AuthService interface
+  auth/
+    service.go         — orchestrates UserClient + TokenService + Repository
+    login.go
+    verify_token.go
+    get_access_token.go
+    get_refresh_token.go
 
-repository/             — refresh token persistence (Redis)
-client/grpc/            — gRPC client to Users service
-config/env/             — env var configs (jwt, redis, grpc, security, rate_limiter)
+internal/repository/auth/ — refresh token persistence (Redis)
+internal/client/grpc/     — gRPC client to Users service
+internal/client/cache/    — Redis cache client
+internal/config/env/      — env var configs (jwt, redis, grpc, security, rate_limiter, metrics, tracing, logger, user_grpc)
 ```
 
 ## Key dependencies

--- a/services/auth/CLAUDE.md
+++ b/services/auth/CLAUDE.md
@@ -1,0 +1,49 @@
+# CLAUDE.md — Auth Service
+
+## What this is
+
+gRPC authentication service. Issues and validates JWT tokens (access + refresh). Delegates credential verification to the Users service via gRPC client.
+
+Port: `:50050`
+
+## Architecture
+
+```
+cmd/main.go → app/app.go → service_provider.go (DI)
+
+handler/auth/
+  login.go             — Login RPC: validate credentials via Users client → issue tokens
+  get_access_token.go  — reissue access token from refresh token
+  get_refresh_token.go — reissue refresh token
+  validate_token.go    — ValidateToken RPC: verify JWT, return claims
+
+service/auth/
+  service.go           — orchestrates UserClient + TokenService + Repository
+  verify_token.go
+  get_access_token.go
+  get_refresh_token.go
+
+repository/             — refresh token persistence (Redis)
+client/grpc/            — gRPC client to Users service
+config/env/             — env var configs (jwt, redis, grpc, security, rate_limiter)
+```
+
+## Key dependencies
+
+- `shared/pkg/go-kit/tokens` — JWT token creation/validation (shared lib)
+- Users service (`:50054`) — credential verification via gRPC
+
+## Service boundaries
+
+| Does | Does NOT |
+|------|----------|
+| Issue JWT (access + refresh) | Authorize (that's AuthZ) |
+| Validate tokens | Manage user profiles |
+| Store refresh tokens (Redis) | Know about S3, buckets, objects |
+
+## Commands
+
+```bash
+go build ./services/auth/...
+go test ./services/auth/...
+```

--- a/services/metadata/CLAUDE.md
+++ b/services/metadata/CLAUDE.md
@@ -1,0 +1,40 @@
+# CLAUDE.md — Metadata Service
+
+## What this is
+
+gRPC metadata service. Stores object/bucket metadata in PostgreSQL. Publishes events to Kafka when objects/buckets are created or deleted.
+
+Port: `:50052`
+
+## Architecture
+
+```
+cmd/main.go → (standard app/service_provider pattern)
+
+handler/metadata/
+  handler.go — implements MetadataServiceServer (currently skeleton)
+```
+
+**Status:** skeleton — handler embeds `UnimplementedMetadataServiceServer`. Business logic not yet implemented.
+
+## Planned responsibilities
+
+- CRUD for bucket metadata (name, owner, created_at)
+- CRUD for object metadata (key, bucket, size, content_type, blob_id, version)
+- Kafka producer: `object-stored`, `object-deleted`, `bucket-deleted`
+- Kafka consumer: none (receives calls from Gateway)
+
+## Service boundaries
+
+| Does | Does NOT |
+|------|----------|
+| Store object/bucket metadata (PostgreSQL) | Store bytes (that's Storage) |
+| Emit Kafka events on mutations | Check permissions (that's AuthZ) |
+| Map object keys to blob_ids | Know about S3 API directly |
+
+## Commands
+
+```bash
+go build ./services/metadata/...
+go test ./services/metadata/...
+```

--- a/services/metadata/CLAUDE.md
+++ b/services/metadata/CLAUDE.md
@@ -9,9 +9,9 @@ Port: `:50052`
 ## Architecture
 
 ```
-cmd/main.go → (standard app/service_provider pattern)
+cmd/server/main.go → (standard app/service_provider pattern)
 
-handler/metadata/
+internal/handler/metadata/
   handler.go — implements MetadataServiceServer (currently skeleton)
 ```
 

--- a/services/storage/CLAUDE.md
+++ b/services/storage/CLAUDE.md
@@ -1,0 +1,61 @@
+# CLAUDE.md — Storage Service
+
+## What this is
+
+gRPC blob storage service. Stores and retrieves raw bytes on the local filesystem. Supports simple put/get/delete and multipart uploads.
+
+Port: `:50053`
+
+## Architecture
+
+```
+cmd/main.go → app/app.go → service_provider.go (DI)
+
+handler/storage/
+  handler.go           — implements StorageServiceServer
+  store_object.go      — StoreObject: client-streaming (chunks → blob)
+  retrieve_object.go   — RetrieveObject: server-streaming (blob → chunks)
+  delete_object.go     — DeleteObject
+  initiate_multipart.go
+  upload_part.go
+  complete_multipart.go
+  abort_multipart.go
+  chunk_reader.go      — helper: reads io.Reader in fixed-size chunks
+  upload_streams.go    — stream adapter helpers
+  client_stream.go
+
+service/storage/
+  service.go           — StorageService interface + constructor
+  store_object.go
+  retrieve_object.go
+  delete_object.go
+  initiate_multipart.go
+  upload_part.go
+  complete_multipart.go
+  abort_multipart.go
+  health_check.go
+
+repository/
+  repository.go        — StorageRepository interface (filesystem ops)
+```
+
+## Key details
+
+- Blobs stored by `blob_id` (UUID), not by object key — mapping is in Metadata service
+- Streaming: StoreObject uses client-streaming, RetrieveObject uses server-streaming
+- Multipart: initiate → upload parts → complete/abort
+
+## Service boundaries
+
+| Does | Does NOT |
+|------|----------|
+| Store/retrieve/delete raw bytes | Know about object keys or metadata |
+| Generate blob_ids | Check permissions |
+| Support multipart uploads | Know about S3 API |
+
+## Commands
+
+```bash
+go build ./services/storage/...
+go test ./services/storage/...
+```

--- a/services/storage/CLAUDE.md
+++ b/services/storage/CLAUDE.md
@@ -9,9 +9,9 @@ Port: `:50053`
 ## Architecture
 
 ```
-cmd/main.go → app/app.go → service_provider.go (DI)
+cmd/server/main.go → internal/app/app.go → internal/app/service_provider.go (DI)
 
-handler/storage/
+internal/handler/storage/
   handler.go           — implements StorageServiceServer
   store_object.go      — StoreObject: client-streaming (chunks → blob)
   retrieve_object.go   — RetrieveObject: server-streaming (blob → chunks)
@@ -20,11 +20,12 @@ handler/storage/
   upload_part.go
   complete_multipart.go
   abort_multipart.go
+  health_check.go
   chunk_reader.go      — helper: reads io.Reader in fixed-size chunks
   upload_streams.go    — stream adapter helpers
   client_stream.go
 
-service/storage/
+internal/service/storage/
   service.go           — StorageService interface + constructor
   store_object.go
   retrieve_object.go
@@ -35,8 +36,12 @@ service/storage/
   abort_multipart.go
   health_check.go
 
-repository/
-  repository.go        — StorageRepository interface (filesystem ops)
+internal/repository/
+  repository.go              — StorageRepository interface
+  storage/repository.go      — filesystem implementation
+  storage/store_blob.go, retrieve_blob.go, delete_blob.go
+  storage/multipart.go       — multipart session management
+  storage/health.go
 ```
 
 ## Key details

--- a/services/users/CLAUDE.md
+++ b/services/users/CLAUDE.md
@@ -9,25 +9,27 @@ Port: `:50054`
 ## Architecture
 
 ```
-cmd/main.go → app/app.go → service_provider.go (DI)
+cmd/server/main.go → internal/app/app.go → internal/app/service_provider.go (DI)
 
-handler/user/
+internal/handler/user/
   handler.go              — implements UserServiceServer
   create.go, get.go, update.go, delete.go
   validate_credentials.go — used by Auth service for login
   update_password.go
 
-service/
+internal/service/
   service.go              — UserService interface
+  user/service.go         — implementation
 
-repository/user/
-  repository.go           — UserRepository interface (PostgreSQL)
-  create.go, get.go, update.go, delete.go
-  get_hashed_password.go, updatePassword.go
+internal/repository/
+  repository.go           — UserRepository interface
+  user/repository.go      — PostgreSQL implementation
+  user/create.go, get.go, update.go, delete.go
+  user/get_hashed_password.go, updatePassword.go
 
-conventer/user/user.go    — domain ↔ proto conversion
-validator/                 — input validation
-config/env/               — pg, grpc, metrics, tracing
+internal/conventer/user/user.go — domain ↔ proto conversion (note: typo in dirname is intentional)
+internal/validator/              — input validation
+internal/config/env/             — pg, grpc, metrics, tracing, logger, rate_limiter
 ```
 
 ## Key details

--- a/services/users/CLAUDE.md
+++ b/services/users/CLAUDE.md
@@ -1,0 +1,56 @@
+# CLAUDE.md — Users Service
+
+## What this is
+
+gRPC user management service. CRUD for user profiles + credential validation. Canonical reference for Go service patterns in this project.
+
+Port: `:50054`
+
+## Architecture
+
+```
+cmd/main.go → app/app.go → service_provider.go (DI)
+
+handler/user/
+  handler.go              — implements UserServiceServer
+  create.go, get.go, update.go, delete.go
+  validate_credentials.go — used by Auth service for login
+  update_password.go
+
+service/
+  service.go              — UserService interface
+
+repository/user/
+  repository.go           — UserRepository interface (PostgreSQL)
+  create.go, get.go, update.go, delete.go
+  get_hashed_password.go, updatePassword.go
+
+conventer/user/user.go    — domain ↔ proto conversion
+validator/                 — input validation
+config/env/               — pg, grpc, metrics, tracing
+```
+
+## Key details
+
+- User IDs are UUID strings (migrated from int64/serial)
+- Migration: `migrations/20260309000000_uuid_migration.sql`
+- Mocks generated via `minimock` (see `repository/generate.go`)
+- This service is the **canonical reference** for handler/service/repository patterns
+
+## Service boundaries
+
+| Does | Does NOT |
+|------|----------|
+| CRUD user profiles | Issue tokens (that's Auth) |
+| Validate credentials (email + password) | Authorize (that's AuthZ) |
+| Store password hashes (bcrypt) | Know about S3, buckets, objects |
+
+## Commands
+
+```bash
+go build ./services/users/...
+go test ./services/users/...
+
+# Run migrations
+bash migration.sh
+```


### PR DESCRIPTION
## Summary
- Add branch, issue, PR, and gh CLI conventions to working guidelines
- Extract service-specific context into per-service CLAUDE.md (auth, metadata, storage, users)
- Remove duplicated domain concepts from root CLAUDE.md